### PR TITLE
improvement: allow custom broadcast ip

### DIFF
--- a/magichue/discover.py
+++ b/magichue/discover.py
@@ -9,13 +9,13 @@ def make_socket(timeout):
     return sock
 
 
-def discover_bulbs(timeout=1):
+def discover_bulbs(timeout=1, broadcast_ip='255.255.255.255'):
     DISCOVERY_PORT = 48899
     DISCOVERY_MSG = b"HF-A11ASSISTHREAD"
     addrs = []
 
     sock = make_socket(timeout)
-    sock.sendto(DISCOVERY_MSG, ('255.255.255.255', DISCOVERY_PORT))
+    sock.sendto(DISCOVERY_MSG, (broadcast_ip, DISCOVERY_PORT))
 
     try:
         while True:


### PR DESCRIPTION
Allowing the IP to be set for networks that don't use `255.255.255.255`.