### PR TITLE
add timeout to Light._connect

### DIFF
--- a/magichue/magichue.py
+++ b/magichue/magichue.py
@@ -144,8 +144,9 @@ class Light(object):
         self._connect()
         self._update_status()
 
-    def _connect(self):
+    def _connect(self, timeout=1):
         self._sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self._sock.settimeout(timeout)
         self._sock.connect((self.addr, self.port))
 
     def _send(self, data):


### PR DESCRIPTION
On some systems the timeout trying to connect to a
bulb using an incorrect address may be 75 seconds
or longer. Add a timeout so that this fails quickly.